### PR TITLE
abstracted away all network logic as a precursor for more easily support...

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@ var ExceptionLogger = require('./lib/exception-logger'),
     conman = require('./lib/con-man');
 
 
-module.exports = function(api_token) {
+module.exports = function(apiKey) {
   // we need to configure a new conman, to use our apiKey, and set it as the default instance
   // so that all our calls to conman.send() use the correctly configured instance
-  conman.init({setDefault: true, apiKey: api_token});
+  conman.init({setDefault: true, apiKey: apiKey});
 
   conman.on('open', function(){ console.log("open");});
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,15 @@
-var ExceptionLogger = require('./lib/exception-logger');
+var ExceptionLogger = require('./lib/exception-logger'),
+    conman = require('./lib/con-man');
 
 
 module.exports = function(api_token) {
-	return new ExceptionLogger(api_token);
+  // we need to configure a new conman, to use our apiKey, and set it as the default instance
+  // so that all our calls to conman.send() use the correctly configured instance
+  conman.init({setDefault: true, apiKey: api_token});
+
+  conman.on('open', function(){ console.log("open");});
+
+  // for now, let's return the same interface using the new abstracted networking stuff
+  // this way, our existing tests should still work
+	return new ExceptionLogger();
 };

--- a/lib/authorizers/base-authorizer.js
+++ b/lib/authorizers/base-authorizer.js
@@ -1,0 +1,36 @@
+var util = require('util');
+
+// Represents the base class for all Authorizers
+function BaseAuthorizer() {
+  // derived children should not do any work in their constructor
+};
+
+// Should be overriden in Authorizers
+// 
+// expects 
+// apiKey:string - the apiKey to authorize with
+// cb:function - a function that takes (err, token) after authorization occurs
+BaseAuthorizer.prototype.authorize = function(apiKey, cb) {
+  throw new Error("Authorizers should override BaseAuthorizer.prototype.authorize");
+};
+
+// Should be overriden in Authorizers
+// 
+// expects
+// nothing, returns bool to indicate if authorized
+// 
+BaseAuthorizer.prototype.authorized = function() {
+  throw new Error("Authorizers should override BaseAuthorizer.prototype.authorized");
+};
+
+// represents failure to authorize. should be err, in the cb above, if there is an error
+function AuthorizerFailedError(msg) {
+  Error.call(this, msg);
+};
+
+util.inherits(AuthorizerFailedError, Error);
+
+module.exports = {
+  BaseAuthorizer: BaseAuthorizer,
+  AuthorizerFailedError: AuthorizerFailedError
+};

--- a/lib/authorizers/websocket-authorizer.js
+++ b/lib/authorizers/websocket-authorizer.js
@@ -1,0 +1,50 @@
+var util = require('util'),
+    BaseAuthorizer = require('./base-authorizer').BaseAuthorizer,
+    AuthorizerFailedError = require('./base-authorizer').AuthorizerFailedError;
+
+// Given a websocket, authenticate it using our protocol
+// when authorize is called
+function WebsocketAuthorizer(ws) {
+  this._ws = ws;
+  this._authorized = false;
+};
+
+util.inherits(WebsocketAuthorizer, BaseAuthorizer);
+
+// Should be overriden in Authorizers
+// 
+// expects 
+// apiKey:string - the apiKey to authorize with
+// cb:function - a function that takes (err, token) after authorization occurs
+WebsocketAuthorizer.prototype.authorize = function(apiKey, cb) {
+  if (!this._ws) return cb(new AuthorizerFailedError("websocket not valid"));
+  if (this._ws.readyState != 1) return cb(new AuthorizerFailedError("websocket not open. state: "+this._ws.readyState));
+  
+  var self = this;
+  var listener = function(event) {
+    self._ws.removeListener('message', listener);
+
+    var data = JSON.parse(event.data);
+    if (data.type === "api_token-response" && data.data === "OK") {
+      self._authorized = true;
+
+      cb(null, data.data);
+    } else {
+      cb(new AuthorizerFailedError(data.data));
+    }
+  };
+
+  this._ws.on('message', listener);
+  this._ws.send(JSON.stringify({type:"api_token", data:apiKey}));
+};
+
+// Should be overriden in Authorizers
+// 
+// expects
+// nothing, returns bool to indicate if authorized
+// 
+WebsocketAuthorizer.prototype.authorized = function() {
+  return this._authorized;
+}
+
+module.exports = WebsocketAuthorizer;

--- a/lib/con-man.js
+++ b/lib/con-man.js
@@ -1,0 +1,91 @@
+var util = require('util'),
+    backoff = require('backoff'),
+    ProviderFailedError = require('./providers/base-provider').ProviderFailedError,
+    EventEmitter = require('events').EventEmitter,
+    RestfulProvider = require('./providers/restful-provider'),
+    MdnsWebsocketProvider = require('./providers/mdns-websocket-provider'),
+    RESTFUL_PROVIDER_ENDPOINT_STRING = "https://api.arewegood.io";
+
+
+// Manages all our connection oriented stuff behind the scenes
+function ConMan() {
+  this._useBuffer = true;
+  this._buffer = [];
+  this._init = false;
+};
+
+// Make ConMan derive from EventEmitter
+util.inherits(ConMan, EventEmitter);
+
+// Makes a decision to either buffer or directly send a message
+// to a provider, based on it's connectivity. expects (ProviderMessage)
+// or (ProviderMessage[]) or (ProviderMessage 1, ProviderMessage 2, ProviderMessage N)
+// as argument(s)
+ConMan.prototype.send = function() {
+  if (!this._init) return this.emit('error', new Error("tried to send before init()"));
+
+  var self = this,
+      args = Array.prototype.slice.call(arguments);
+
+  for (var i = 0 ; i < args.length ; i++) {
+    var item = args[i];
+
+    if (this._useBuffer) {
+      this._buffer.push(item);
+    } else {
+      this.provider.send(item, function(err) {
+        if (err) self.emit('error', err);
+      });
+    }
+  }
+};
+
+// Initialize the instance with important config
+// 
+// takes:
+// {
+//    apiKey:string - the api key to use when authenticating a provider. default: null
+//    useProxy:boolean - do we even bother trying the use the proxy? default: true
+// }
+ConMan.prototype.init = function(opts) {
+  var self = this;
+
+  this._opts = opts || {useProxy: true};
+
+  if (this._opts.useProxy === false) {
+    this.provider = new RestfulProvider(RESTFUL_PROVIDER_ENDPOINT_STRING, this._opts.apiKey);
+  } else {
+    this.provider = new MdnsWebsocketProvider(this._opts.apiKey);
+  }
+
+  this.provider.on('open', function() {
+        self.emit('open');
+  });
+
+  this.provider.on('authorized', function() {
+    console.log(self._buffer.length);
+    self._useBuffer = false;
+    if (self._buffer.length > 0) {
+      console.log(JSON.stringify(self._buffer));
+      self.provider.send(self._buffer);
+    }
+  });
+
+  this.provider.on('close', function() {
+    self.emit('close');
+    self._useBuffer = true;
+  });
+
+  this.provider.on('error', function(e) {
+    // If mdns completely fails, switch over to Restful
+    if (e instanceof ProviderFailedError && e.provider instanceof MdnsWebsocketProvider) {
+      self.provider = new RestfulProvider(RESTFUL_PROVIDER_ENDPOINT_STRING, self._opts.apiKey);
+    }
+
+    self.emit('error', e);
+  });
+
+  this._init = true;
+};
+
+module.exports = new ConMan();

--- a/lib/exception-logger.js
+++ b/lib/exception-logger.js
@@ -1,109 +1,30 @@
-var WebSocket = require('faye-websocket'),
-	Promise = require('promise'),
-	serviceName = "awgproxy",
-	ipAddressingIndex = 0, //for ipv4, 1 for ipv6
-	serviceTimeout = 2000,
-	mdns = require('mdns'),
-	browser = mdns.createBrowser({name: serviceName, protocol: 'tcp'}),
-	_browserUp = false;
+var util = require('util'),
+		EventEmitter = require('events').EventEmitter,
+		conman = require('./con-man');
 
-module.exports = function(api_token) {
-	var self = this,
-		_apiToken = api_token,
-		_ws = null,
-		_queue = [],
-		_appsUp = false,
-		_logger = function(){};
+function ExceptionLogger() {
 
-	if (!_browserUp) {
-		_browserUp = true;
-		browser.start();
-	}
+	var self = this;
 
-	browser.on('serviceUp', function(service) {
-		if (_appsUp) return;
-		_appsUp = true;
-
-		_logger("[exception-logger] connecting to");
-		_logger(service);
-
-		if (_ws && _ws.readyState === 1) return;
-
-		// do some stuff to authenticate a socket
-		// note: this is REALLY basic and suck-ish
-		var _authenticate = function(socket, token) {
-			return new Promise(function(resolve, reject) {
-				socket.on('message', function(event) {
-					var p = JSON.parse(event.data);
-					_logger("[exception-logger] ", p);
-					if (p.type === "api_token-response") {
-						if (p.data === "OK") {
-							return resolve(p.data);
-						}
-					}
-				});
-				socket.send(JSON.stringify({type: "api_token", data: token}));
-
-				setTimeout(function() {
-					reject("TIMEOUT");
-				}, serviceTimeout);
-			});
-		};
-
-		// do some bs to make a socket that, on close, recreates itself
-		var createSocket = function(host, port) {
-			_logger("[exception-logger] creating socket["+host+":"+port+"]...");
-
-			_ws = new WebSocket.Client("ws://"+host+":"+port);
-			_ws.on('open', function() {
-				_logger("[exception-logger] trying to authenticate...");
-				_authenticate(_ws, _apiToken).done(function(status) {
-					if (_queue.length > 0 && status === "OK") {
-						for (var i = 0; i < _queue.length; i++) {
-							_ws.send(JSON.stringify(_queue[i]));
-						};
-					} //TODO else kill _ws
-				});
-			});
-			_ws.on('close', function(event) {
-				_ws = null;
-				if (_appsUp) createSocket(host, port); //TODO: implement backoff logic
-			});
-		};
-
-		createSocket(service.addresses[ipAddressingIndex], service.port);
+	conman.on('error', function(e) {
+		self.emit('error', e);
 	});
-
-	browser.on('serviceDown', function(service) {
-		_appsUp = false;
-
-		if (_ws) _ws.close();
-		_ws = null;
-	});
-
 
 	var writers = ["trace","info","debug","error"],
 		writer = function(method) {
 			var args = Array.prototype.slice.call(arguments, 1);
 			if (args.length == 0) return;
 			if (args.length == 1) args = args[0];
-
-			if (_ws === null) { //TODO account for auth here (might not be needed if above todo sets _ws = null)
- 				_queue.push({type: method, data: args});
- 				_logger("[exception-logger] queuing", args);
- 			} else {
- 				_ws.send(JSON.stringify({type: method, data: args}));
- 				_logger("[exception-logger] sending", args);
- 			}
+			console.log(args);
+			conman.send({type: method, data: args});
 		};
 	
 	// bind all the writers
 	for (var i = 0; i < writers.length; i++) {
 		self[writers[i]] = writer.bind(self, writers[i]);
 	}
-
-	// lets us optionally log data to this function
-	self.log = function(logger) {
-		_logger = logger;
-	};
 };
+
+util.inherits(ExceptionLogger, EventEmitter);
+
+module.exports = ExceptionLogger;

--- a/lib/providers/base-provider.js
+++ b/lib/providers/base-provider.js
@@ -29,6 +29,11 @@ BaseProvider.prototype.write = function(jsonData) {
 BaseProvider.prototype.send = function() {
   var args = Array.prototype.slice.call(arguments);
 
+  // if you aren't sending anything, you shouldn't be calling this
+  if (args.length == 0) {
+    return this.emit('error', new Error("send should be called with arguments!"));
+  }
+
   // if we're passed an array of ProviderMessage's, extract it
   if (args.length == 1 && args[0] instanceof Array) {
     args = args[0];

--- a/lib/providers/base-provider.js
+++ b/lib/providers/base-provider.js
@@ -1,0 +1,80 @@
+var util = require('util'),
+    EventEmitter = require('events').EventEmitter;
+
+// Represents the base class for all providers
+function BaseProvider() {
+  // derived children should start connection and authentication logic
+  // in the constructor, and emit 'open' or 'close' as a result of success 
+  // or failure. backoff logic should also be implemented.
+};
+
+util.inherits(BaseProvider, EventEmitter);
+
+// Should be overriden in providers
+// 
+// expects jsonData:string - a string of json to write to the provider
+BaseProvider.prototype.write = function(jsonData) {
+  throw new Error("Providers should override BaseProvider.prototype.write");
+};
+
+// This is the method that ConMan calls to send data to a provider
+// it will check if messages are of the right type, and if so, write
+// them to the provider as JSON.
+// 
+// This should not be overriden by providers
+// 
+// expects (ProviderMessage)
+// or (ProviderMessage[]) or (ProviderMessage 1, ProviderMessage 2, ProviderMessage N)
+// as argument(s)
+BaseProvider.prototype.send = function() {
+  var args = Array.prototype.slice.call(arguments);
+
+  // if we're passed an array of ProviderMessage's, extract it
+  if (args.length == 1 && args[0] instanceof Array) {
+    args = args[0];
+  }
+
+  // test the first instance for provider message-ness. this is a compromise in type safety and perf
+  if (!ProviderMessage.IsInstance(args[0])) {
+    this.emit('error', new Error("tried to send a non-ProviderMessage: "+ args[0].toString()));
+  }
+
+  //encode and write()
+  var encoded = JSON.stringify(args);
+  this.write(encoded);
+};
+
+// Represents complete failure in a provider, meaning
+// it is not useable
+function ProviderFailedError(msg, provider) {
+  Error.call(this, msg);
+  this.provider = provider;
+};
+
+util.inherits(ProviderFailedError, Error);
+
+// Represents a non-connected error, where
+// something is trying to be written to a disconnected provider
+function ProviderOfflineError(msg) {
+  Error.call(this, msg);
+};
+
+util.inherits(ProviderOfflineError, Error);
+
+// Represents a message to be sent by a provider
+function ProviderMessage(type, data) {
+  this.type = type;
+  this.data = data;
+};
+
+// Returns true if an object is an instance of a ProviderMessage
+ProviderMessage.IsInstance = function(obj) {
+  return obj instanceof ProviderMessage || (typeof(obj.type) !== "undefined" && typeof(obj.data) !== "undefined");
+};
+
+module.exports = {
+  BaseProvider: BaseProvider,
+  ProviderFailedError: ProviderFailedError,
+  ProviderMessage: ProviderMessage,
+  ProviderOfflineError: ProviderOfflineError
+};

--- a/lib/providers/mdns-websocket-provider.js
+++ b/lib/providers/mdns-websocket-provider.js
@@ -1,0 +1,70 @@
+var util = require('util'),
+    mdns = require('mdns'),
+    WebSocket = require('faye-websocket'),
+    backoff = require('backoff'),
+    BaseProvider = require('./base-provider').BaseProvider,
+    ProviderFailedError = require('./base-provider').ProviderFailedError,
+    ProviderOfflineError = require('./base-provider').ProviderOfflineError,
+    WebsocketAuthorizer = require('../authorizers/websocket-authorizer'),
+    browser = mdns.createBrowser({name: "awgproxy", protocol: 'tcp'}),
+    IP_ADDR_INDEX = 0; // 0=ipv4, 1=ipv6.
+
+function MdnsWebsocketProvider(apiKey) {
+  var self = this;
+
+  browser.on('serviceUp', function(service) {
+    if (self._ws) return;
+
+    self.emit('serviceUp', service);
+
+    self._ws = new WebSocket.Client("ws://" + service.addresses[IP_ADDR_INDEX] + ":" + service.port);
+    self._ws._authorizer = new WebsocketAuthorizer(self._ws);
+
+    self._ws.on('open', function() {
+      self.emit('open');
+      self._ws._authorizer.authorize(apiKey, function(err, token) {
+        if (err) {
+          self._ws.close();
+          self.emit('error', err);
+        }
+        else self.emit('authorized', token);
+      });
+    });
+
+    self._ws.on('close', function() {
+      self._ws = null;
+      self.emit('close');
+      //TODO implement backoff, and only emit error when backoff fails
+      self.emit('error', new ProviderFailedError("socket closed", self));
+    });
+  });
+
+  browser.on('serviceDown', function(service) {
+    self.emit('serviceDown', service);
+
+    if (self._ws) {
+      self._ws.close();
+      self._ws = null;
+    }
+  });
+
+  browser.start();
+};
+
+util.inherits(MdnsWebsocketProvider, BaseProvider);
+
+// write json data to underlying websocket
+MdnsWebsocketProvider.prototype.write = function(jsonData) {
+  if (this._ws.readyState == 1) {
+    if (this._ws._authorizer.authorized()) {
+      this._ws.send(jsonData);
+    } else {
+      this.emit('error', new ProviderOfflineError("cannot send data, not authorized."));
+    }
+  } else {
+    this.emit('error', new ProviderOfflineError("cannot send data, not connected. state: "+this._ws.readyState));
+  }
+};
+
+// export our constructor
+module.exports = MdnsWebsocketProvider;

--- a/lib/providers/restful-provider.js
+++ b/lib/providers/restful-provider.js
@@ -1,0 +1,1 @@
+module.exports = function(){};

--- a/mocks/consume.js
+++ b/mocks/consume.js
@@ -1,5 +1,7 @@
-var sdk = require('../index')("nonsense")
-sdk.log(console.log)
+var sdk = require('../index')("1167891")
+sdk.on('error', function(e) {
+  console.log(e);
+});
 
 sdk.trace("started")
 sdk.info("hi mom")

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "backoff": "^2.4.1",
     "faye-websocket": "^0.9.2",
     "mdns": "git://github.com/hashtag-include/node_mdns",
-    "promise": "^6.1.0"
+    "promise": "^6.1.0",
+    "usage": "^0.5.0"
   },
   "devDependencies": {
     "mocha": "^2.1.0"


### PR DESCRIPTION
...ing different messages, and switch transports from ws to http rest

this is a hell of a commit, as the entire networking stack has been pulled out. as such, there's a bit to talk about here.

First of all, the conceptual model we're using is component based; provider components define transport behavior, meaning they deal directly with maintaining a connection, and serializing data over the wire. Then theres authorizers, which are responsible for authorizing a provider (transport) such that it can send data.

We have a concept of messages, which is roughly defined as `ProviderMessage` in `base-provider.js`. basically a message is any object that looks like `{type:"string", data: {object}}`.

And finally, `con-man` wraps up configuration and management of all these pieces, such that the other components of the sdk can just `conman.send(new ProviderMessage())` and the management of all things network won't get in the way. That being said, **there is one caveat**: you need to `conman.init({apiKey:"string"})` before any components of the sdk can make calls to `conman.send()`. this is currently done in the main entry point, `index.js`.
