### PR TITLE
adding support for uncaughtException handling, with explicit consumer se...

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,19 @@
 var ExceptionLogger = require('./lib/exception-logger'),
-    conman = require('./lib/con-man');
+    conman = require('./lib/con-man'),
+    logger = new ExceptionLogger(),
+    uncaughtHandler = require('./lib/uncaught-handler')({
+      //bind these args to the uncaughtHandler instance
+      logger: logger,
+      timeout: 15000,
+      console: console,
+      exitCode: 1,
+      callOthers: true
+    });
 
+// set the uncaughtHandler as a property of logger
+// this is so that we canreturn an object
+// that is a combination of the logger and the uncaughtHandler
+logger.uncaughtHandler = uncaughtHandler;
 
 module.exports = function(apiKey) {
   // we need to configure a new conman, to use our apiKey, and set it as the default instance
@@ -8,8 +21,7 @@ module.exports = function(apiKey) {
   conman.init({setDefault: true, apiKey: apiKey});
 
   conman.on('open', function(){ console.log("open");});
-
-  // for now, let's return the same interface using the new abstracted networking stuff
-  // this way, our existing tests should still work
-	return new ExceptionLogger();
+ 
+  // return our logger-ish object
+  return logger;
 };

--- a/lib/uncaught-handler.js
+++ b/lib/uncaught-handler.js
@@ -1,0 +1,39 @@
+// takes things to bind to the uncaught handler instance
+// returns a function that should be attached (by the consumer)
+// to process.on('uncaughtException');
+// 
+// opts:
+// {
+//    logger:ExceptionLogger, //arewegood logger we log to
+//    console:Object, //Console-like object that we .error to
+//    exitCode:Number, //number we process.exit with
+//    timeout:Number, //how long we wait before forcing process.exit
+//    callOthers:Boolean, //do we call any other bound listeners if they exist?
+// }
+module.exports = function(opts) {
+  var uncaughtHandler = function(err) {
+    // report the error
+    opts.console.error('error', err.stack);
+    opts.logger.error(err);
+
+    // call other uncaughtException listeners
+    if (opts.callOthers) {
+      var others = process.listeners('uncaughtException');
+      for (var i = 0 ; i < others.length ; i++) {
+        if (others[i] !== uncaughtHandler) {
+          others[i](err);
+        }
+      }
+    }
+
+    // set a timeout to kill the app
+    var kt = setTimeout(function() {
+      process.exit(opts.exitCode);
+    }, opts.timeout);
+
+    // don't block on the timeout to kill the app (the following may have custom logic to kill it sooner)
+    kt.unref();
+  };
+
+  return uncaughtHandler;
+};

--- a/mocks/consume.js
+++ b/mocks/consume.js
@@ -1,9 +1,16 @@
-var sdk = require('../index')("1167891")
+var sdk = require('../index')("5f91dc3de55d4b079480a0b5d1a7327e")
 sdk.on('error', function(e) {
   console.log(e);
 });
 
+// verify logging
 sdk.trace("started")
 sdk.info("hi mom")
 sdk.debug("oh no things happened")
 sdk.error("really terrible things!")
+
+// verify our binding to uncaughtException
+// this guy should call any other bound handlers, before
+// killing the application
+process.on('uncaughtException', sdk.uncaughtHandler);
+throw new Error("test123");


### PR DESCRIPTION
...tup. updated mocks/consume "test"

This lets the consumer do the following snippit

```
var sdk = require('arewegood');

process.on('uncaughtException', sdk.uncaughtHandler);
```

which will appropriately handle uncaught exceptions, logging them to our platform, writing them to console, executing any other handlers, and then setting a `process.exit` timeout. @trjast i think this is probably the best way to do this as we 1) avoid `process.on` in our source, 2) call any other callbacks, 3) capture the error for us, and 4) show it via console as is default behavior.
